### PR TITLE
Icomoon patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Currently, there is not a search result page in this theme, so I suggest that yo
 *  `NIUX2_DUOSHUO_THREAD_KEY` string(default ""), type of your duoshuo thread key. If you want to use article's slug for its thread key, change it to `slug', or it will use part of the article's url as its thread key by default.
 *  `NIUX2_LIB_THEME` string(default SITEURL+'/theme'), url of niu-x2-sidebar theme root
 *  `NIUX2_LIB_FONT_ICONS` string(default SITEURL+'/theme/font-icons'), url of your custom font icons.
+*  `NIUX2_LIB_FONTAWESOME` string(default '//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/'), url of font awesome icons.
 *  `NIUX2_LIB_BOOTSTRAP` string(default SITEURL+'/theme'), url of bootstrap library
 *  `NIUX2_LIB_JQUERY` string(default SITEURL+'/theme/js/jquery-1.10.2.min.js'), url of jquery
 *  `NIUX2_LAZY_LOAD` bool(default False), enable lazy loading images.

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Currently, there is not a search result page in this theme, so I suggest that yo
 *  `NIUX2_FOOTER_LINKS` a `NIUX2_HEADER_SECTIONS` format list shown right after your copyright info in the footer section
 *  `NIUX2_DISPLAY_TITLE` boolean(default True), whether to display the title of article and page
 *  `NIUX2_DUOSHUO_SHORTNAME` string(default None), your duoshuo shortname. Note that if `DISQUS_SITENAME` is set, duoshuo will not be loaded.
-*  `NIUX2_DUOSHUO_THREAD_KEY` string(default ""), type of your duoshuo thread key. If you want to use article's slug for its thread key, change it to `slug', or it will use part of the article's url as its thread key by default.
+*  `NIUX2_DUOSHUO_THREAD_KEY` string(default ""), type of your duoshuo thread key. If you want to use article's slug for its thread key, change it to 'slug' or 'date' for using article's date. Otherwise, it will use part of the article's url as its thread key by default.
 *  `NIUX2_LIB_THEME` string(default SITEURL+'/theme'), url of niu-x2-sidebar theme root
 *  `NIUX2_LIB_FONT_ICONS` string(default SITEURL+'/theme/font-icons'), url of your custom font icons.
 *  `NIUX2_LIB_FONTAWESOME` string(default '//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/'), url of font awesome icons.

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Currently, there is not a search result page in this theme, so I suggest that yo
 *  `NIUX2_DUOSHUO_THREAD_KEY` string(default ""), type of your duoshuo thread key. If you want to use article's slug for its thread key, change it to 'slug' or 'date' for using article's date. Otherwise, it will use part of the article's url as its thread key by default.
 *  `NIUX2_LIB_THEME` string(default SITEURL+'/theme'), url of niu-x2-sidebar theme root
 *  `NIUX2_LIB_FONT_ICONS` string(default SITEURL+'/theme/font-icons'), url of your custom font icons.
-*  `NIUX2_LIB_FONTAWESOME` string(default '//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/'), url of font awesome icons.
+*  `NIUX2_LIB_FONTAWESOME` string(default ''), url of font awesome icons.
 *  `NIUX2_LIB_BOOTSTRAP` string(default SITEURL+'/theme'), url of bootstrap library
 *  `NIUX2_LIB_JQUERY` string(default SITEURL+'/theme/js/jquery-1.10.2.min.js'), url of jquery
 *  `NIUX2_LAZY_LOAD` bool(default False), enable lazy loading images.

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,7 @@
     {% set theme_loc = NIUX2_LIB_THEME if NIUX2_LIB_THEME else SITEURL + '/theme' %}
     {% set bootstrap_loc = NIUX2_LIB_BOOTSTRAP if NIUX2_LIB_BOOTSTRAP else SITEURL + '/theme' %}
     {% set icons_loc = NIUX2_LIB_FONT_ICONS if NIUX2_LIB_FONT_ICONS else SITEURL + '/theme/font-icons' %}
+    {% set font_awesome_loc = NIUX2_LIB_FONTAWESOME if NIUX2_LIB_FONTAWESOME else '//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/' %}
     {% block head %}
     {% block head_init %}
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
@@ -12,6 +13,7 @@
     <link rel="shortcut icon" type="image/x-icon" href="{{ NIUX2_FAVICON_URL | default('/favicon.png') }}">
     <link rel="stylesheet" href="{{ bootstrap_loc }}/css/bootstrap.min.css" type="text/css" />
     <link rel="stylesheet" href="{{ icons_loc }}/style.min.css" type="text/css" />
+    <link rel="stylesheet" href="{{ font_awesome_loc }}/css/font-awesome.min.css">
     <link rel="stylesheet" href="{{ theme_loc }}/css/niu2.min.css" type="text/css" />
     {% endblock head_init %}
     

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,7 @@
     {% set theme_loc = NIUX2_LIB_THEME if NIUX2_LIB_THEME else SITEURL + '/theme' %}
     {% set bootstrap_loc = NIUX2_LIB_BOOTSTRAP if NIUX2_LIB_BOOTSTRAP else SITEURL + '/theme' %}
     {% set icons_loc = NIUX2_LIB_FONT_ICONS if NIUX2_LIB_FONT_ICONS else SITEURL + '/theme/font-icons' %}
-    {% set font_awesome_loc = NIUX2_LIB_FONTAWESOME if NIUX2_LIB_FONTAWESOME else '//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/' %}
+    {% set font_awesome_loc = NIUX2_LIB_FONTAWESOME if NIUX2_LIB_FONTAWESOME else '' %}
     {% block head %}
     {% block head_init %}
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
@@ -13,7 +13,9 @@
     <link rel="shortcut icon" type="image/x-icon" href="{{ NIUX2_FAVICON_URL | default('/favicon.png') }}">
     <link rel="stylesheet" href="{{ bootstrap_loc }}/css/bootstrap.min.css" type="text/css" />
     <link rel="stylesheet" href="{{ icons_loc }}/style.min.css" type="text/css" />
+    {% if NIUX2_LIB_FONTAWESOME %}
     <link rel="stylesheet" href="{{ font_awesome_loc }}/css/font-awesome.min.css">
+    {% endif %}
     <link rel="stylesheet" href="{{ theme_loc }}/css/niu2.min.css" type="text/css" />
     {% endblock head_init %}
     

--- a/templates/duoshuo.html
+++ b/templates/duoshuo.html
@@ -5,7 +5,7 @@
 {% elif content.settings['NIUX2_DUOSHUO_THREAD_KEY'] == 'date' %}
     {% set thread_key = content.date.strftime('%Y-%m-%d %H:%M:%S') %}
 {% endif %}
-<div class="ds-thread" data-thread-key="{{ thread_key }}" data-title="{{ content.title }}" data-url="{{ content._context['SITEURL'] }}/{{ content.url }}"></div>
+<div class="ds-thread" data-thread-key="{{ thread_key }}" data-title="{{ content.title|e }}" data-url="{{ content._context['SITEURL'] }}/{{ content.url }}"></div>
 <!-- 多说评论框 end -->
 <!-- 多说公共JS代码 start (一个网页只需插入一次) -->
 <script type="text/javascript">

--- a/templates/duoshuo.html
+++ b/templates/duoshuo.html
@@ -2,6 +2,8 @@
 {% set thread_key = '/' ~ content.url %}
 {% if content.settings['NIUX2_DUOSHUO_THREAD_KEY'] == 'slug' %}
     {% set thread_key = content.slug %}
+{% elif content.settings['NIUX2_DUOSHUO_THREAD_KEY'] == 'date' %}
+    {% set thread_key = content.date.strftime('%Y-%m-%d %H:%M:%S') %}
 {% endif %}
 <div class="ds-thread" data-thread-key="{{ thread_key }}" data-title="{{ content.title }}" data-url="{{ content._context['SITEURL'] }}/{{ content.url }}"></div>
 <!-- 多说评论框 end -->


### PR DESCRIPTION
1. 修复标题中带双引号时多说后台标题显示不全的问题（转义问题）
2. NIUX2_DUOSHUO_THREAD_KEY增加'date'选项，可自由选择使用slug还是date作为key
3. 增加NIUX2_LIB_FONTAWESOME选项