### PR TITLE
Add "SITEURL" to template header.html

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -14,7 +14,7 @@
                         <ul class="nav navbar-nav">
                         {% if NIUX2_HEADER_SECTIONS %}
                         {% for section in NIUX2_HEADER_SECTIONS %}
-                            <li><a href="{{ section[2] }}" title="{{ section[1] }}">
+                            <li><a href="{{ SITEURL }}/{{ section[2] }}" title="{{ section[1] }}">
                                 <i class="{{ section[3] }}"></i>{{ section[0] }}</a>
                             </li>
                         {% endfor %}


### PR DESCRIPTION
修复当 NIUX2_HEADER_SECTIONS 配置为相对路径时，URL 生成错误的 BUG：

例如配置如下时：

```
NIUX2_HEADER_SECTIONS = [
    ('关于', 'about me', 'about.html', 'icon-anchor'),
    ('标签', 'tags', 'tag/', 'icon-tag'),
    ('存档', 'archives', 'archives.html', 'icon-archive'),
]
```

在某一文章页面点击 header 中任意一个 section 会访问一个错误的 URL。
